### PR TITLE
Added support for this plugin's expected data attributes in versions of WP prior to 5.0

### DIFF
--- a/includes/sections-menu-common.php
+++ b/includes/sections-menu-common.php
@@ -86,6 +86,39 @@ if ( ! class_exists( 'Section_Menus_Common' ) ) {
 
 			return $output;
 		}
+
+		/**
+		 * Applies content filtering overrides to prevent expected
+		 * data attributes from being stripped by WordPress KSES filtering
+		 * prior to WP 5.0.
+		 *
+		 * @author Jo Dickson
+		 * @since 1.1.1
+		 * @param array $tags Global $allowedposttags array
+		 * @param mixed $context Context for which to retrieve tags
+		 * @return array Modified post tag array
+		 */
+		public static function kses_valid_attributes( $tags, $context ) {
+			if ( $context === 'post' ) {
+				// Tags on which our custom data attributes should be valid.
+				$data_attr_tags = array(
+					'div',
+					'section',
+					'aside',
+					'article'
+				);
+
+				foreach ( $data_attr_tags as $t ) {
+					if ( ! isset( $tags[$t]['data-*'] ) ) {
+						$existing_rules = isset( $tags[$t] ) ? $tags[$t] : array();
+						$tags[$t] = array_merge( $existing_rules, array(
+							'data-section-link-title' => true
+						) );
+					}
+				}
+			}
+			return $tags;
+		}
 	}
 }
 

--- a/sections-menu.php
+++ b/sections-menu.php
@@ -40,3 +40,7 @@ add_action( 'init', array( 'Section_Menu_Items_Shortcode', 'register_shortcode' 
 add_action( 'wp_enqueue_scripts', array( 'Section_Menus_Common', 'enqueue_assets' ), 10, 0 );
 
 add_filter( 'the_content', array( 'Section_Menus_Common', 'format_shortcode_output' ), 10, 1 );
+
+// Enable necessary data attributes on elements that would otherwise
+// be filtered by WordPress's KSES filters:
+add_filter( 'wp_kses_allowed_html', array( 'Section_Menus_Common', 'kses_valid_attributes' ), 10, 2 );


### PR DESCRIPTION
Enables the `data-section-link-title` attribute for KSES filtering on `div`, `section`, `aside`, and `article` elements in WP versions prior to 5.0 (newer versions allow data attributes on all elements globally).  Prevents `data-section-link-title` attributes from getting wiped out when saved by non-superusers and when swapping between the plaintext and WYSIWYG editors.